### PR TITLE
Prevent PHP warning: Undefined variable $field

### DIFF
--- a/core/components/ace/elements/plugins/ace.plugin.php
+++ b/core/components/ace/elements/plugins/ace.plugin.php
@@ -129,7 +129,7 @@ switch ($modx->event->name) {
 
 $modxTags = (int) $modxTags;
 $script = '';
-if ($field) {
+if (!empty($field)) {
     $script .= "MODx.ux.Ace.replaceComponent('$field', '$mimeType', $modxTags);";
 }
 


### PR DESCRIPTION
This message gets logged _a lot_ in MODX 3 (with error reporting on). PHP 8.0.10.

I think it may be caused by the OnManagerPageBeforeRender event being enabled for the plugin, but it not actually doing anything on that event. Because of that $field never gets set. By checking it's not empty, which also does an isset(), the problem is avoided. However, maybe the unused event should also be removed from the build. 