### PR TITLE
Move settings into an own file

### DIFF
--- a/core/components/ace/lexicon/en/setting.inc.php
+++ b/core/components/ace/lexicon/en/setting.inc.php
@@ -1,0 +1,24 @@
+$_lang['area_general'] = 'General settings';
+
+$_lang['setting_ace.theme'] = 'Editor theme';
+$_lang['setting_ace.theme_desc'] = 'Available themes: ambiance, chaos, chrome, clouds, clouds_midnight, cobalt, crimson_editor, dawn, dreamweaver, eclipse, github, idle_fingers, katzenmilch, kr, kuroir, merbivore, merbivore_soft, mono_industrial, monokai, pastel_on_dark, solarized_dark, solarized_light, terminal, textmate, tomorrow, tomorrow_night, tomorrow_night_blue, tomorrow_night_bright, tomorrow_night_eighties, twilight, vibrant_ink, xcode.';
+$_lang['setting_ace.word_wrap'] = 'Word wrap';
+$_lang['setting_ace.word_wrap_desc'] = 'Wrap long lines.';
+$_lang['setting_ace.font_size'] = 'Font size';
+$_lang['setting_ace.font_size_desc'] = 'Editor font size.';
+$_lang['setting_ace.soft_tabs'] = 'Soft tabs';
+$_lang['setting_ace.soft_tabs_desc'] = 'Replace tabs by spaces.';
+$_lang['setting_ace.tab_size'] = 'Tab size';
+$_lang['setting_ace.tab_size_desc'] = 'Tab width to use.';
+$_lang['setting_ace.fold_widgets'] = 'Fold widgets';
+$_lang['setting_ace.fold_widgets_desc'] = 'Show fold widgets in the gutter.';
+$_lang['setting_ace.show_invisibles'] = 'Invisible characters';
+$_lang['setting_ace.show_invisibles_desc'] = 'Show whitespaces, tabs and line endings.';
+$_lang['setting_ace.snippets'] = 'Snippets';
+$_lang['setting_ace.snippets_desc'] = 'Code snippets you can expand by pressing “Tab” key. Snippet example:<br /><br /><pre>\nsnippet getr\n	[!getResources? parents=`${1}`${2}]]\n</pre></br>You can insert “Tab” character by pressing Alt + 09';
+$_lang['setting_ace.height'] = 'Edit area height';
+$_lang['setting_ace.height_desc'] = 'Editor height in pixel unit. If left blank, a defaul height will be used.';
+$_lang['setting_ace.grow'] = 'Fit height to text';
+$_lang['setting_ace.grow_desc'] = 'The height of the editor will be adjusted to the text. The minimum height will be equal to the option ace.height. Possible values: Empty - height does not fit the text; The number is greater than 0 - the height is adjusted to the text but not more than the value; 0 - height is customized for text, height is unlimited. ';
+$_lang['setting_ace.html_elements_mime'] = 'MIME-type for html elements';
+$_lang['setting_ace.html_elements_mime_desc'] = 'This type will be used by the editor for html elements - templates, chunks and resources with html type. If not specified, the default type will be used';


### PR DESCRIPTION
Currently I get the following debug warning in the MODX error log:

[2022-01-30 17:44:59] (DEBUG @ /.../core/model/modx/modlexicon.class.php : 259) An error occurred while trying to cache lexicon/en/ace/setting (lexicon/language/namespace/topic)

The setting lexicon topic is automatically used by the system settings grid. Moving the setting lexicon entries to an own file avoids that DEBUG entry.

The setting lexicon entries have to be removed from the default.inc.php. This has to be done for all languages. 

Sorry I dont speak any russian.